### PR TITLE
add theme collector

### DIFF
--- a/packages/crayon/src/collector/__tests__/collectThemes.test.ts
+++ b/packages/crayon/src/collector/__tests__/collectThemes.test.ts
@@ -1,0 +1,51 @@
+import collectThemes from '../collectThemes'
+
+test('generates a collection item for each theme', () => {
+  const themes = {
+    MonoLisa: {
+      className: 'mona lisa',
+    },
+    LastSupper: {
+      className: 'Last Supper',
+    },
+  }
+
+  expect(collectThemes(themes))
+    .toEqual({
+      MonoLisa: {
+        className: '.mona-lisa',
+      },
+      LastSupper: {
+        className: '.last-supper',
+      },
+    })
+})
+
+test('add modifiers to collection item', () => {
+  const themes = {
+    MonoLisa: {
+      className: 'mona lisa',
+    },
+    LastSupper: {
+      className: 'Last Supper',
+      modifiers: {
+        success: {},
+        error: {},
+      },
+    },
+  }
+
+  expect(collectThemes(themes))
+    .toEqual({
+      MonoLisa: {
+        className: '.mona-lisa',
+      },
+      LastSupper: {
+        className: '.last-supper',
+        modifiers: {
+          success: '.last-supper--success',
+          error: '.last-supper--error',
+        },
+      },
+    })
+})

--- a/packages/crayon/src/collector/__tests__/collector.test.ts
+++ b/packages/crayon/src/collector/__tests__/collector.test.ts
@@ -1,0 +1,43 @@
+import collector from '../collector'
+
+test('resolves and collect all themes from config', () => {
+  const themeCollection = collector({
+    themes: ['src/__fixtures__/themes/**/*.theme.js'],
+  })
+
+  expect(themeCollection)
+    .toEqual(
+      {
+        MonaLisa: {
+          className: '.mona-lisa',
+        },
+        LastSupper: {
+          className: '.last-supper',
+        },
+        LadyWithAnErmine: {
+          className: '.lady-with-an-ermine',
+          modifiers: {
+            awesome: '.lady-with-an-ermine--awesome',
+          },
+        },
+        TheStarryNight: {
+          className: '.the-starry-night',
+        },
+        CafeTerraceAtNight: {
+          className: '.cafe-terrace-at-night',
+        },
+        TheSower: {
+          className: '.the-sower',
+        },
+        TheIncredulityOfThomas: {
+          className: '.the-incredulity-of-thomas',
+        },
+        TheNightWatch: {
+          className: '.the-night-watch',
+        },
+        TheStormOnTheSeaOfGalilee: {
+          className: '.the-storm-on-the-sea-of-galilee',
+        },
+      },
+    )
+})

--- a/packages/crayon/src/collector/__tests__/generateClassName.test.ts
+++ b/packages/crayon/src/collector/__tests__/generateClassName.test.ts
@@ -1,0 +1,26 @@
+import generateClassName from '../generateClassName'
+
+test('name can contain leading dot', () => {
+  expect(generateClassName('.with-dot'))
+    .toEqual('.with-dot')
+})
+
+test('prefixes the name with dot if does not have one', () => {
+  expect(generateClassName('without-dot'))
+    .toEqual('.without-dot')
+})
+
+test('should escape the name\'s special characters with tailwindUtils.e()', () => {
+  expect(generateClassName('with/special/chars'))
+    .toEqual('.with\\/special\\/chars')
+})
+
+test('generates name with modifier', () => {
+  expect(generateClassName('with/modifier', 'success'))
+    .toEqual('.with\\/modifier--success')
+})
+
+test('component names must be kebab-case', () => {
+  expect(generateClassName('The Class Name/With_Special:characters', 'WithAModifier'))
+    .toEqual('.the-class-name\\/with-special\\:characters--with-a-modifier')
+})

--- a/packages/crayon/src/collector/collectThemes.ts
+++ b/packages/crayon/src/collector/collectThemes.ts
@@ -1,0 +1,33 @@
+import { ThemeCollection, UserTheme, UserThemeCollection } from '../types'
+import generateClassName from './generateClassName'
+
+export default function collectThemes (themes: UserThemeCollection): ThemeCollection {
+  return Object.entries(themes).reduce((collection, [themeName, theme]) => {
+    return Object.assign(collection, collectTheme(themeName, theme))
+  }, {})
+}
+
+function collectTheme (name: string, theme: UserTheme) {
+  return {
+    [name]: {
+      className: generateClassName(theme.className),
+      ...extractThemeModifiers(theme),
+    },
+  }
+}
+
+function extractThemeModifiers (theme: UserTheme) {
+  if (theme.modifiers) {
+    return {
+      modifiers: Object.entries(theme.modifiers).reduce((modifiers, [modifierName]) => {
+        return Object.assign(modifiers, extractModifier(theme.className, modifierName))
+      }, {}),
+    }
+  }
+}
+
+function extractModifier (className: string, modifierName: string) {
+  return {
+    [modifierName]: generateClassName(className, modifierName),
+  }
+}

--- a/packages/crayon/src/collector/collector.ts
+++ b/packages/crayon/src/collector/collector.ts
@@ -1,0 +1,7 @@
+import { ThemeCollection, UserConfig } from '../types'
+import collectThemes from './collectThemes'
+import resolveThemes from '../utils/resolveThemes'
+
+export default function collector (config: UserConfig): ThemeCollection {
+  return collectThemes(resolveThemes(config))
+}

--- a/packages/crayon/src/collector/generateClassName.ts
+++ b/packages/crayon/src/collector/generateClassName.ts
@@ -1,0 +1,28 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import escapeClassName from 'tailwindcss/lib/util/escapeClassName'
+
+export default function generateClassName (name: string, modifier?: string): string {
+  return `.${escapeClassName(convertToKebabCase(`${removeLeadingDot(name)}${addModifier(modifier)}`))}`
+}
+
+function removeLeadingDot (name: string): string {
+  if (name.startsWith('.', 0)) {
+    return name.substring(1)
+  }
+  return name
+}
+
+function addModifier (modifier?: string): string | undefined {
+  if (modifier) {
+    return `--${modifier}`
+  }
+  return ''
+}
+
+function convertToKebabCase (text: string): string {
+  return text.replace(/([A-Z])([A-Z])/g, '$1-$2')
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase()
+}

--- a/packages/crayon/src/collector/index.ts
+++ b/packages/crayon/src/collector/index.ts
@@ -1,0 +1,1 @@
+export { default } from './collector'

--- a/packages/crayon/src/types/Collector.ts
+++ b/packages/crayon/src/types/Collector.ts
@@ -1,0 +1,11 @@
+type ThemeModifiers = {
+  [name: string]: string
+}
+type Theme = {
+  className: string
+  modifiers?: ThemeModifiers
+}
+
+export type ThemeCollection = {
+  [name: string]: Theme
+}

--- a/packages/crayon/src/types/index.ts
+++ b/packages/crayon/src/types/index.ts
@@ -2,6 +2,7 @@ export * from './Generator'
 export * from './Tailwindcss'
 export * from './Theme'
 export * from './Config'
+export * from './Collector'
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace


### PR DESCRIPTION
This PR adds theme `collector` utility for generating a list of themes with their classNames.

```js
const themeCollection = collector({
   // configuration
})
```
`themeCollection` contains a list of all themes resolved from the configuration:
```js
themeCollection: {
  myTheme: {
    className: '...',
    modifiers: {
      modifierName: {
        className: '...',
      }
    }
  }
}
```