### PR TITLE
prevent attrs to override controlled props

### DIFF
--- a/packages/vue/src/components/HelperText/HelperText.test.ts
+++ b/packages/vue/src/components/HelperText/HelperText.test.ts
@@ -58,3 +58,20 @@ test('should not be visible if HelperTextContext.hidden is true', () => {
   renderHelperTextWithProvider({ hidden: true })
   expect(getHelperText()).not.toBeVisible()
 })
+
+test('user must not be able to modify controlled props', () => {
+  renderInlineComponent({
+    template: '<HelperText id="user" hidden/>',
+    components: { HelperText },
+
+    setup () {
+      provideHelperTextContext({
+        id: 'context',
+        hidden: false,
+      })
+    },
+  })
+
+  expect(getHelperText()).toHaveAttribute('id', 'context')
+  expect(getHelperText()).toBeVisible()
+})

--- a/packages/vue/src/components/HelperText/HelperText.ts
+++ b/packages/vue/src/components/HelperText/HelperText.ts
@@ -2,13 +2,19 @@ import { defineComponent, h } from 'vue'
 import { useHelperTextContext } from '../../contexts'
 
 export default defineComponent({
-  setup (props, { slots }) {
+  inheritAttrs: false,
+
+  setup (props, {
+    slots,
+    attrs,
+  }) {
     const {
       id,
       hidden,
     } = useHelperTextContext()
 
     return () => h('span', {
+      ...attrs,
       id,
       hidden,
     }, slots.default?.())

--- a/packages/vue/src/components/Label/Label.test.ts
+++ b/packages/vue/src/components/Label/Label.test.ts
@@ -73,3 +73,20 @@ test('should pass uncontrolled props to label element',
     expect(getLabel()).toHaveAttribute('data-test-id', 'test')
   }),
 )
+
+test('user must not be able to modify controlled props', () => {
+  renderInlineComponent({
+    template: '<LabelComponent id="user" for="user"/>',
+    components: { LabelComponent },
+
+    setup () {
+      provideLabelContext({
+        id: 'context',
+        htmlFor: 'context',
+      })
+    },
+  })
+
+  expect(getLabel()).toHaveAttribute('id', 'context')
+  expect(getLabel()).toHaveAttribute('for', 'context')
+})

--- a/packages/vue/src/components/Label/Label.ts
+++ b/packages/vue/src/components/Label/Label.ts
@@ -2,13 +2,19 @@ import { defineComponent, h } from 'vue'
 import { useLabelContext } from '../../contexts'
 
 export default defineComponent({
-  setup (props, { slots }) {
+  inheritAttrs: false,
+
+  setup (props, {
+    slots,
+    attrs,
+  }) {
     const {
       id,
       htmlFor,
     } = useLabelContext()
 
     return () => h('label', {
+      ...attrs,
       id,
       for: htmlFor,
     }, slots.default?.())


### PR DESCRIPTION
In Vue, additional attributes passed to a component will automatically apply to the root element.
To protect properties coming from the context from user manipulation, we should handle this manually.
This PR fixes this issue for Label and HelperText components.